### PR TITLE
Fix logical index recycling bug in check_agg_complete (monthly & seasonal)

### DIFF
--- a/R/calc_indices_helpers.R
+++ b/R/calc_indices_helpers.R
@@ -391,9 +391,13 @@ check_agg_complete<-function(r,agg){
       cut=NULL
       cm=unique(substring(chelp,6,7))
       for (i in cm){
-        if (!all(is.element(years[substring(chelp,6,7)==i],range(years)))){
+        years_for_month <- as.integer(substring(chelp[substring(chelp, 6, 7) == i], 1, 4))
+        interior <- years_for_month[!is.element(years_for_month, range(years))]
+        if (length(interior) > 0) {
           cut=c(cut,paste0(years,"-",i))
           message(paste0("warning: data for month", i, "is not complete. Index is not calculated for this month."))
+        } else {
+          cut=c(cut,paste0(years_for_month,"-",i))
         }
       }
       }
@@ -405,9 +409,13 @@ check_agg_complete<-function(r,agg){
       cs=unique(substring(chelp,6,8))
 
       for (i in cs){
-        if (!(all(is.element(years[substring(chelp,6,8)==i],range(years))) & length(years)>2)){
+        years_for_season <- as.integer(substring(chelp[substring(chelp, 6, 8) == i], 1, 4))
+        interior <- years_for_season[!is.element(years_for_season, range(years))]
+        if (length(interior) > 0) {
           cut=c(cut,paste0(years,"-",i))
           message(paste0("warning: data for season", i, "is not complete. Index is not calculated for this season."))
+        } else {
+          cut=c(cut,paste0(years_for_season,"-",i))
         }
       }
       }


### PR DESCRIPTION
## Summary

- `years[substring(chelp,6,7)==i]` and the equivalent seasonal line indexed `years` (all unique years) with a logical vector derived from `chelp` (incomplete period labels), which can differ in length — causing R to either recycle the short logical (returning all years) or pad with `NA` (silently skipping the check).
- Fixed by filtering `chelp` first to get only the incomplete labels for the current period, then extracting years from those labels directly.
- Boundary-year incomplete periods (first/last year of the series) are now silently excluded (mapped to `NA`) instead of incorrectly dropping the entire month/season across all years.
- Interior incomplete periods still trigger a warning and exclude the full month/season, preserving the original behavior for real data gaps.

## Test plan

- [ ] Verify that a time series ending mid-season (e.g. current year with incomplete MAM) no longer warns and no longer drops the season for all years
- [ ] Verify that a time series ending mid-month no longer warns and no longer drops the month for all years
- [ ] Verify that a genuine interior data gap still produces a warning and excludes the full season/month

🤖 Generated with [Claude Code](https://claude.com/claude-code)